### PR TITLE
Fix redundant sampling in AutoRegressiveSampler

### DIFF
--- a/closd/diffusion_planner/utils/sampler_util.py
+++ b/closd/diffusion_planner/utils/sampler_util.py
@@ -43,7 +43,7 @@ class AutoRegressiveSampler():
     
     def sample(self, model, shape, **kargs):
         bs = shape[0]
-        n_iterations = (self.required_frames // self.args.pred_len) + 1
+        n_iterations = (self.required_frames + self.args.pred_len - 1) // self.args.pred_len
         samples_buf = []
         cur_prefix = deepcopy(kargs['model_kwargs']['y']['prefix'])  # init with data
         if self.args.autoregressive_include_prefix:


### PR DESCRIPTION
In AutoRegressive Sampler, when `required_frames` is a multiple of `pred_len`, the sampling wastes an iteration for nothing due to false rounding.

For example, when `self.required_frames == 120`, `self.args.pred_len == 40` (the default setting when doing stand-alone DiP generation), the original code calculates `n_iterations` as 4. This generates 160 frames, which gets cropped to 120 frames. 

```python
n_iterations = (self.required_frames // self.args.pred_len) + 1  # (120 // 40) + 1 = 4
...
full_batch = torch.cat(samples_buf, dim=-1)[..., :self.required_frames]  # 4*40 = 160 -> 120
```

After this fix, the redundant iteration is saved.

```python
n_iterations = (self.required_frames + self.args.pred_len - 1) // self.args.pred_len  # (120 + 40 - 1) // 40 = 3
...
full_batch = torch.cat(samples_buf, dim=-1)[..., :self.required_frames]  # 3*40 = 120 -> 120
```